### PR TITLE
Added params back to Tyopheus options

### DIFF
--- a/lib/monster_mash/request.rb
+++ b/lib/monster_mash/request.rb
@@ -74,7 +74,7 @@ module MonsterMash
     end
 
     # Typhoeus options.
-    [:body, :headers, :connect_timeout, :timeout,
+    [:body, :headers, :connect_timeout, :timeout, :params,
     :user_agent, :response, :cache_timeout, :follow_location,
     :max_redirects, :proxy, :proxy_username,:proxy_password,
     :disable_ssl_peer_verification, :ssl_cert, :ssl_cert_type, 


### PR DESCRIPTION
Tried using Monster Mash and noticed that I was getting undefined method anytime i tried to pass params per the docs. Looks like it was removed from the last merge. Not sure if it that intentional but the specs and the readme still listed it being there - so I'm guessing it was a mistake and just added it back in.
